### PR TITLE
Add ECS cluster, service task-definition

### DIFF
--- a/container_definitions.json
+++ b/container_definitions.json
@@ -1,0 +1,21 @@
+[
+  {
+    "name": "example",
+    "image": "nginx:latest",
+    "essential": true,
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-region": "ap-northeast-1",
+        "awslogs-stream-prefix": "nginx",
+        "awslogs-group": "/ecs/example"
+      }
+    },
+    "portMappings": [
+      {
+        "protocol": "tcp",
+        "containerPort": 80
+      }
+    ]
+  }
+]

--- a/study.tf
+++ b/study.tf
@@ -337,3 +337,81 @@ resource "aws_lb_listener_rule" "example" {
     values = ["/*"]
   }
 }
+
+resource "aws_ecs_cluster" "example" {
+  name ="examlpe"
+}
+
+resource "aws_ecs_task_definition" "example" {
+  family = "example"
+  cpu = "256"
+  memory = "512"
+  network_mode = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  container_definitions = file("./container_definitions.json")
+  execution_role_arn = module.ecs_task_exexution_role.iam_role_arn
+}
+
+resource "aws_ecs_service" "example" {
+  name = "example"
+  cluster = aws_ecs_cluster.example.arn
+  task_definition = aws_ecs_task_definition.example.arn
+  desired_count = 2
+  launch_type = "FARGATE"
+  platform_version = "1.3.0"
+  health_check_grace_period_seconds = 60
+
+  network_configuration {
+    assign_public_ip = false
+    security_groups = [module.nginx_sg.security_group_id]
+
+    subnets = [
+      aws_subnet.private_0.id,
+      aws_subnet.private_1.id,
+    ]
+  }
+
+  load_balancer { 
+    target_group_arn = aws_lb_target_group.example.arn
+    container_name = "example"
+    container_port = 80
+  }
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+}
+
+module "nginx_sg" {
+  source = "./modules/security_group"
+  name = "ngins-sg"
+  vpc_id = aws_vpc.example.id
+  port = 80
+  cidr_blocks = [aws_vpc.example.cidr_block]
+}
+
+resource "aws_cloudwatch_log_group" "for_ecs" {
+  name = "/ecs/example"
+  retention_in_days = 180
+}
+
+data "aws_iam_policy" "ecs_task_execution_role_policy" {
+  arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_iam_policy_document" "ecs_task_execution" {
+  source_json = data.aws_iam_policy.ecs_task_execution_role_policy.policy
+
+  statement {
+    effect = "Allow"
+    actions = ["ssm:getParameters", "kms:Decrypt"]
+    resources = ["*"]
+  }
+}
+
+module "ecs_task_exexution_role" {
+  source = "./modules/iam_role"
+  name   = "ecs-task-execution"
+  identifier = "ecs-tasks.amazonaws.com"
+  policy = data.aws_iam_policy_document.ecs_task_execution.json
+}


### PR DESCRIPTION
Until No.8 section in Pragmatic Terraform on AWS

- ECS
  - Service
  - Task definition
  - Output CloudWatchLog